### PR TITLE
Autodarts-Browser implementiert

### DIFF
--- a/main.py
+++ b/main.py
@@ -413,7 +413,7 @@ service_name = 'autodarts'
 restart_service_via_ssh(hostname, port, username, password, service_name)
 
 if browser_installed:
-    browser_choice = input("Browser oben oder unten? (1/2)[1]: ")
+    browser_choice = input("Browserfenster oben oder unten? (1/2)[1]: ")
     if browser_choice == '1':
         browser = "board1_id"
     elif browser_choice == '2':

--- a/main.py
+++ b/main.py
@@ -323,9 +323,33 @@ if not os.path.exists(config_file):
                                 browser_username, browser_password)
             browser_path = find_remote_file(
                 browser_ssh, 'darts-browser.py', '/home/' + browser_username, exclude_dirs)
+            if browser_path:
+                ssh_browser_dir = os.path.dirname(browser_path)
+                ssh_browser_config = ssh_browser_dir + '/config.ini'
+                clear_screen()
+                show_menu()
+                print(
+                    f"Der Autodarts-Browser wurde in {ssh_browser_dir} gefunden: ")
+                print("")
+                browser_config = input(
+                    f"Drücke Enter um, [{ssh_browser_config}] zu verwenden: ") or ssh_browser_config
+                same_host = True
+            else:
+                clear_screen()
+                show_menu()
+                print("Autodarts-Browser wurde nicht gefunden.")
+                print("")
+                manual_config = input(
+                    "Möchten Sie die Browser-Konfiguration manuell eingeben? (ja/nein): ").strip().lower()
+                if manual_config == 'ja' or manual_config == 'yes' or manual_config == 'y' or manual_config == 'j':
+                    browser_path = input("Pfad zum Autodarts-Browser: ")
+                    same_host = True
+                else:
+                    print("Überspringe Browser-Konfiguration.")
+                    browser_path = None
             same_host = False
             print("Noch nicht implementiert.")
-            browser_path = None
+            # browser_path = None
 
     # Füge Browser-Konfiguration hinzu, falls vorhanden
     if browser_path:

--- a/main.py
+++ b/main.py
@@ -530,6 +530,7 @@ service_name = 'autodarts'
 restart_service_via_ssh(hostname, port, username, password, service_name)
 
 if browser_installed:
+    same_host = config['browser']['same_host']
     browser_choice = input("Browserfenster oben oder unten? (1/2)[1]: ")
     if browser_choice == '1':
         browser = "board1_id"

--- a/main.py
+++ b/main.py
@@ -311,6 +311,10 @@ if not os.path.exists(config_file):
                     print("Überspringe Browser-Konfiguration.")
                     browser_path = None
         else:
+            clear_screen()
+            show_menu()
+            print("Autodarts-Browser SSH Verbindungsdaten")
+            print("")
             browser_hostname = input("SSH Host für Browser: ")
             browser_port = input("SSH Port [22]: ") or '22'
             browser_username = input("SSH Benutzer für Browser: ")
@@ -333,7 +337,7 @@ if not os.path.exists(config_file):
                 print("")
                 browser_config = input(
                     f"Drücke Enter um, [{ssh_browser_config}] zu verwenden: ") or ssh_browser_config
-                same_host = True
+                same_host = False
             else:
                 clear_screen()
                 show_menu()
@@ -343,7 +347,7 @@ if not os.path.exists(config_file):
                     "Möchten Sie die Browser-Konfiguration manuell eingeben? (ja/nein): ").strip().lower()
                 if manual_config == 'ja' or manual_config == 'yes' or manual_config == 'y' or manual_config == 'j':
                     browser_path = input("Pfad zum Autodarts-Browser: ")
-                    same_host = True
+                    same_host = False
                 else:
                     print("Überspringe Browser-Konfiguration.")
                     browser_path = None

--- a/main.py
+++ b/main.py
@@ -538,6 +538,12 @@ if browser_installed:
     else:
         browser = "board1_id"
     new_browser_config = f'./config_browser_{user}.ini'
+    if not same_host:
+        hostname = str(config['browser']['ssh']['hostname'])
+        port = int(config['browser']['ssh']['port'])
+        username = str(config['browser']['ssh']['username'])
+        password = str(decrypt_password(
+            config['browser']['ssh']['password'], key))
     download_file_via_ssh(hostname, port, username,
                           password, browser_path, local_browser_config)
     # Ändere den Wert in der INI-Datei

--- a/main.py
+++ b/main.py
@@ -316,7 +316,7 @@ if not os.path.exists(config_file):
             print("Autodarts-Browser SSH Verbindungsdaten")
             print("")
             browser_hostname = input("SSH Host für Browser: ")
-            browser_port = input("SSH Port [22]: ") or '22'
+            browser_port = input("SSH Port [22]: ") or 22
             browser_username = input("SSH Benutzer für Browser: ")
             browser_password = getpass.getpass("SSH Passwort für Browser: ")
             encrypted_browser_password = encrypt_password(
@@ -377,7 +377,6 @@ if not os.path.exists(config_file):
                 }
             }
         else:
-
             config = {
                 'general': {
                     'board_name': board_name
@@ -531,6 +530,10 @@ restart_service_via_ssh(hostname, port, username, password, service_name)
 
 if browser_installed:
     same_host = config['browser']['same_host']
+    clear_screen()
+    show_menu()
+    print("In welchem Browserfenster soll das Board geöffnet werden?")
+    print("")
     browser_choice = input("Browserfenster oben oder unten? (1/2)[1]: ")
     if browser_choice == '1':
         browser = "board1_id"

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import toml
 import os
 from cryptography.fernet import Fernet
 import sqlite3
+import configparser
 
 directory = './config'
 if not os.path.exists(directory):


### PR DESCRIPTION
Es wurde bei der Erstellung der Konfiguration eine Abfrage hinzugefügt, womit der Autodartsbrowser konfiguriert werden kann. Dabei ist es egal ob er auf dem selben Host läuft oder auf einem anderen.